### PR TITLE
Fixes problem with passing value via `withValue` method

### DIFF
--- a/src/Specification/Filter/Postgres/ILike.php
+++ b/src/Specification/Filter/Postgres/ILike.php
@@ -10,7 +10,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class ILike implements FilterInterface
 {
-    private readonly Like $like;
+    private Like $like;
 
     public function __construct(string $expression, mixed $value = null, string $pattern = '%%%s%%')
     {
@@ -20,8 +20,9 @@ final class ILike implements FilterInterface
     public function withValue(mixed $value): ?SpecificationInterface
     {
         $filter = clone $this;
+        $filter->like = $filter->like->withValue($value);
 
-        return $filter->like->withValue($value);
+        return $filter;
     }
 
     public function getExpression(): string

--- a/tests/Specification/Filter/Postgres/ILikeTest.php
+++ b/tests/Specification/Filter/Postgres/ILikeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\DataGrid\Specification\Filter\Postgres;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\DataGrid\Specification\Filter\Postgres\ILike;
+
+final class ILikeTest extends TestCase
+{
+    public function testWithValue(): void
+    {
+        $filter = new ILike('foo');
+
+        $filter = $filter->withValue('bar');
+        $this->assertInstanceOf(ILike::class, $filter);
+
+        $this->assertSame($filter->getValue(), 'bar');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    |❌ 
| New feature?  | ❌

```php
$filter = new ILike('foo');

// Before
$filter->withValue('bar') instanseof ILike // false

// After
$filter->withValue('bar') instanseof ILike // true
```